### PR TITLE
Bugfix/UI - Prevent Button text from overflowing

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Description
The text within `Button` components are allowed to overflow the element's padding box. For example, using the _Grid View_ in the `Applications` page and shrinking the window results in the following text overflow:
![Screenshot 2025-05-28 at 10 22 58 PM](https://github.com/user-attachments/assets/daa8453f-1e18-44fa-b40a-7a1cde3ef951)

To prevent this issue, all button components can include the `overflow-hidden` class (from Tailwindcss) by default. Any buttons that don't include text will be unaffected by the change, and any that do will seamlessly hide any overflowing text.

## Checklist
- [X] I have tested the code
- [X] I have updated the documentation if necessary
- [X] I followed the project's coding guidelines
